### PR TITLE
Solved : 2-Sum Sorted.c

### DIFF
--- a/bug-fixes/2-Sum Sorted.c
+++ b/bug-fixes/2-Sum Sorted.c
@@ -1,20 +1,28 @@
-// 2-Sum Sorted - Off-by-one error
 int* twoSum(int* nums, int numsSize, int target, int* returnSize) {
     int left = 0, right = numsSize - 1;
+
     while (left < right) {
         int sum = nums[left] + nums[right];
+
+        // Check if sum matches target
         if (sum == target) {
             int* result = (int*)malloc(2 * sizeof(int));
-            result[0] = left + 1; // Error: Off-by-one issue
-            result[1] = right + 1;
+
+            // Correct indexing - assuming problem requires 1-based indexing
+            result[0] = left + 1; // convert 0-based index to 1-based
+            result[1] = right + 1; // convert 0-based index to 1-based
+
             *returnSize = 2;
             return result;
+
         } else if (sum < target) {
-            left++;
+            left++;  // Move left pointer to the right
         } else {
-            right--;
+            right--; // Move right pointer to the left
         }
     }
+
+    // No solution found
     *returnSize = 0;
     return NULL;
 }


### PR DESCRIPTION
Solving this issue[ #2 ](https://github.com/sandipkumardey/45DayChallengeBySandip/issues/2)

Fixed the off-by one error in the 2-sum sorted array :

What is off by one error  :
An off-by-one error is a common programming mistake where a loop, index, or range is incorrect by one position. It often happens when dealing with array indices, ranges, or iteration boundaries, especially in contexts involving 0-based or 1-based indexing.

Approach 😊:

1.Two pointer technique : 
left pointer at the start of the array (index 0).
right pointer at the end of the array (index n-1 where n is the length of the array).

Check the sum of elements at these pointers:

Calculate the sum of the values at the left and right pointers: arr[left] + arr[right].
Compare the sum with the target:

If the sum equals the target, you've found the pair and can return or output the result.
If the sum is less than the target, move the left pointer to the right (i.e., increase left by 1) to try and increase the sum.
If the sum is greater than the target, move the right pointer to the left (i.e., decrease right by 1) to try and decrease the sum.
Repeat until the pointers cross:

Continue this process until left is no longer less than right. If no pair is found by then, the target sum does not exist in the array.

